### PR TITLE
Update HistoricDbModel.ts

### DIFF
--- a/migrations/20190309151403_initial.ts
+++ b/migrations/20190309151403_initial.ts
@@ -12,7 +12,7 @@ module.exports.up = async knex => {
     table.dateTime('updatedAt', 3)
     table.dateTime('validFrom', 3)
     table.boolean('obsolete').notNullable()
-    table.string('originalId')
+    table.string('currentId')
     table.string('firstProperty').notNullable()
     table.integer('secondProperty').notNullable()
   })

--- a/src/models/HistoricDbModel.ts
+++ b/src/models/HistoricDbModel.ts
@@ -4,7 +4,7 @@ import * as objection from 'objection'
 export default class HistoricDbModel extends BaseModel {
   validFrom!: Date
   obsolete!: boolean
-  originalId!: string | null
+  currentId!: string | null
 
   $beforeInsert() {
     super.$beforeInsert()
@@ -41,7 +41,7 @@ export default class HistoricDbModel extends BaseModel {
         validFrom: old.updatedAt,
         createdAt: now,
         updatedAt: now,
-        originalId: old.id,
+        currentId: old.id,
       }
       const newProps = {
         ...props,


### PR DESCRIPTION
I think `originalId` is misleading a little bit. I originally thought each copy would inherit the previous item's `id` in the `originalId` field. I see that instead, the `id` of the current item always stays the same, the old one is saved as a copy. I like this a lot better, but I think renaming `originalId` to `currentId` would make things clearer. 

![image](https://user-images.githubusercontent.com/240318/68076199-d66cbd00-fdb1-11e9-9776-39e758c983c4.png)